### PR TITLE
SystemContainer holds default world object

### DIFF
--- a/include/es/system.h
+++ b/include/es/system.h
@@ -4,6 +4,8 @@
 #ifndef ES_SYSTEM_H
 #define ES_SYSTEM_H
 
+#include <es/world.h>
+
 namespace es
 {
 
@@ -21,6 +23,10 @@ class System
 
         // Derived classes must implement this function
         virtual void update(float dt) = 0;
+
+        void setDefaultWorld(es::World* world) { this->world = world;}
+    protected:
+       es::World* world{ nullptr };
 };
 
 }

--- a/include/es/systemcontainer.h
+++ b/include/es/systemcontainer.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <iostream>
 #include <es/system.h>
+#include <es/world.h>
 
 namespace es
 {
@@ -90,6 +91,9 @@ class SystemContainer
         template <typename T>
         T* getSystem();
 
+        // Sets the default world object that all registered systems get a reference to
+        void registerWorld(es::World* world);
+
     private:
 
         struct SystemPtr
@@ -105,6 +109,8 @@ class SystemContainer
 
         std::vector<SystemPtr> systems;
         std::unordered_map<std::type_index, size_t> systemTypes;
+
+        World* world{ nullptr };
 
         // Returns the position of a system by type index
         size_t getIndex(const std::type_index& type) const;
@@ -124,6 +130,7 @@ size_t SystemContainer::add(Args&&... args)
         index = systems.size();
         systems.emplace_back(std::make_unique<T>(std::forward<Args>(args)...), typeIndex);
         systemTypes[typeIndex] = index;
+        systems[index].ptr->setDefaultWorld(world);
     }
     else
         std::cout << "SystemContainer: Warning, '" << typeIndex.name() << "' was already added.\n";

--- a/src/es/systemcontainer.cpp
+++ b/src/es/systemcontainer.cpp
@@ -49,4 +49,6 @@ void SystemContainer::updateSystemTypes(size_t start)
         systemTypes[systems[i].typeIndex] = i;
 }
 
+void SystemContainer::registerWorld(es::World* world) { this->world = world; }
 }
+

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -18,7 +18,7 @@ int main()
 namespace esTests
 {
 
-double getElapsedTime(const auto& start)
+double getElapsedTime(const std::chrono::time_point<std::chrono::system_clock>& start)
 {
     return std::chrono::duration<double>(std::chrono::system_clock::now() - start).count();
 }
@@ -765,7 +765,9 @@ void eventTests()
 
 void systemTests()
 {
-    es::SystemContainer systems;
+	es::World world;
+	es::SystemContainer systems;
+	systems.registerWorld(&world);
     auto id1 = systems.add<System1>();
     auto id2 = systems.add<System2>();
     auto id3 = systems.add<System3>();
@@ -787,6 +789,7 @@ void systemTests()
     systems.add<System2>();
     systems.add<System3>();
     systems.add<System4>("test");
+	systems.add<System5>();
 
     systems.initializeAll();
     systems.updateAll(0);

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -8,6 +8,7 @@
 #include <es/serialize.h>
 #include <es/system.h>
 #include <iostream>
+#include <assert.h>
 
 namespace esTests
 {
@@ -184,6 +185,26 @@ class System4: public es::System
 
     private:
         std::string str;
+};
+
+class System5: public es::System
+{
+    public:
+        System5()
+        {
+            std::cout << "System5::System5()\n";
+        }
+
+        void initialize()
+        {
+            std::cout << "System5::initialize()\n";
+        }
+
+        void update(float dt)
+        {
+            std::cout << "System5::update()\n";
+            assert(world != nullptr, "es::System::world is uninitialized");
+        }
 };
 
 }


### PR DESCRIPTION
SystemContainer now holds a pointer to a default es::World object that all systems are initialized with.

Changed double getElapsedTime(const auto& start) to
double getElapsedTime(const std::chrono::time_pointstd::chrono::system_clock& start)
for conformance with MSVC compilers.
